### PR TITLE
Cannot edit saved templates after #674

### DIFF
--- a/api/v3/MosaicoTemplate.php
+++ b/api/v3/MosaicoTemplate.php
@@ -76,7 +76,7 @@ function civicrm_api3_mosaico_template_get($params) {
     if (_civicrm_api3_mosaico_template_getDomainFrom($baseTemplateURL)) {
       $urlParts = parse_url($baseTemplateURL);
       $templatePath = $urlParts['path'];
-      $currentURL =  \Civi::paths()->getVariable('cms.root', 'url') . $templatePath;
+      $currentURL =  \Civi::paths()->getVariable('cms.root', 'url') . '/' . $templatePath;
     } else {
       $currentURL = $baseTemplateURL;
     }


### PR DESCRIPTION
https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/pull/674#issuecomment-3052460362

https://chat.civicrm.org/civicrm/pl/8ru7afftr7g1bx1itaqbb947zc

I have encountered an issue with a site newly updated to Mosaico 3.7 and hit an issue on   CiviCRM 6.4 as well as 5.81.3  all on WordPess.   Now if we creatre a new mailing from a user created template (based on versafix in our case)     We get this error when trying to use the template
```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://cvdemo.tadpole.ccwp-content/uploads/civicrm/ext/uk.co.vedaconsulting.mosaico/packages/mosaico/templates/versafix-1/template-versafix-1.html. (Reason: CORS request did not succeed). Status code: (null).
```
We've checked the `civicrm.settings.php` to see if the changing `CIVICRM_UF_BASEURL` to have a `/` but it made no difference.   

The issue is in the stored metadata of the template we have not stored the leading slash before `wp-content/uploads/civicrm/ext/uk.co.vedaconsulting.mosaico/packages/mosaico/templates/versafix-1/template-versafix-1.html`  

Reverting the patch fixes the issue.

Alternatively modifying line 79 to

```
$currentURL =  \Civi::paths()->getVariable('cms.root', 'url') . '/' . $templatePath;
```

Also fixes the issue.   I am unsure how either change will affect this issue.   

Change results in the following on WP

before:
`cv php:eval "echo CRM_Utils_System::baseURL();"`

result:

`https://cvdemo.example.org/`

After this PR:

`cv php:eval "echo \Civi::paths()->getVariable('cms.root', 'url') ;"`

result:

`https://cvdemo.example.org`



